### PR TITLE
Feature/Lobby UI 및 기본기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.6.8",
         "eslint-plugin-import": "^2.29.1",
         "react": "^18.2.0",
+        "react-calendar": "^5.0.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.23.1",
         "styled-components": "^6.1.11",
@@ -1567,6 +1568,14 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/@wojtekmaj/date-utils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz",
+      "integrity": "sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==",
+      "funding": {
+        "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -1896,6 +1905,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -2928,6 +2945,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-user-locale": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.2.tgz",
+      "integrity": "sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==",
+      "dependencies": {
+        "mem": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3529,6 +3557,32 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mem": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+      "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3568,6 +3622,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/minimatch": {
@@ -3727,6 +3789,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -3927,6 +3997,30 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-calendar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-5.0.0.tgz",
+      "integrity": "sha512-bHcE5e5f+VUKLd4R19BGkcSQLpuwjKBVG0fKz74cwPW5xDfNsReHdDbfd4z3mdjuUuZzVtw4Q920mkwK5/ZOEg==",
+      "dependencies": {
+        "@wojtekmaj/date-utils": "^1.1.3",
+        "clsx": "^2.0.0",
+        "get-user-locale": "^2.2.1",
+        "warning": "^4.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {
@@ -4655,6 +4749,14 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.6.8",
     "eslint-plugin-import": "^2.29.1",
     "react": "^18.2.0",
+    "react-calendar": "^5.0.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.23.1",
     "styled-components": "^6.1.11",

--- a/src/pages/lobby/components/dropdown-button.tsx
+++ b/src/pages/lobby/components/dropdown-button.tsx
@@ -1,0 +1,63 @@
+import React, { ReactNode, useState, useRef } from 'react';
+import styled from 'styled-components';
+import QuickButton from './quick-button';
+import useOutsideClick from '../hooks/use-outside-click';
+
+interface DropdownButtonProps {
+  children: ReactNode;
+}
+
+const groupList = ['그룹1', '그룹2', '그룹3', '그룹4'];
+
+const DropdownButton: React.FC<DropdownButtonProps> = ({ children }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const handleButtonClick = () => {
+    setIsDropdownOpen((prevState) => !prevState);
+  };
+
+  const handleDropdownClose = () => {
+    setIsDropdownOpen(false);
+  };
+
+  useOutsideClick(ref, handleDropdownClose);
+
+  return (
+    <S.DropdownButtonWrapper ref={ref}>
+      <QuickButton onClick={handleButtonClick}>{children}</QuickButton>
+      <S.DropdownBox $isOpen={isDropdownOpen}>
+        {groupList.map((item) => (
+          <S.DropdownList key={item} onClick={handleDropdownClose}>
+            {item}
+          </S.DropdownList>
+        ))}
+      </S.DropdownBox>
+    </S.DropdownButtonWrapper>
+  );
+};
+
+const S = {
+  DropdownButtonWrapper: styled.div`
+    position: relative;
+  `,
+  DropdownBox: styled.ul<{ $isOpen: boolean }>`
+    position: absolute;
+    border: 1px solid black;
+    border-top: none;
+    border-bottom: none;
+    width: 100%;
+    display: ${({ $isOpen }) => ($isOpen ? 'block' : 'none')};
+  `,
+  DropdownList: styled.li`
+    border-bottom: 1px solid black;
+    padding: 2px;
+    cursor: pointer;
+
+    &:hover {
+      background-color: #f0f0f0;
+    }
+  `,
+};
+
+export default DropdownButton;

--- a/src/pages/lobby/components/my-calendar.tsx
+++ b/src/pages/lobby/components/my-calendar.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import Calendar from 'react-calendar';
+import styled from 'styled-components';
+import 'react-calendar/dist/Calendar.css';
+
+type ValuePiece = Date | null;
+type Value = ValuePiece | [ValuePiece, ValuePiece];
+
+const MyCalendar = () => {
+  const [selectedDate, setSelectedDate] = useState<Value>(new Date());
+  return (
+    <S.MyCalender>
+      <Calendar onChange={setSelectedDate} value={selectedDate} />
+      <p>선택된 데이트 객체 {selectedDate?.toLocaleString()}</p>
+    </S.MyCalender>
+  );
+};
+
+export default MyCalendar;
+
+const S = {
+  MyCalender: styled.div`
+    width: 544px;
+    height: 400px;
+    border: 1px solid black;
+  `,
+};

--- a/src/pages/lobby/components/my-schedule-list.tsx
+++ b/src/pages/lobby/components/my-schedule-list.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+const MyScheduleList = () => {
+  return <S.MyScheduleList>my-schedule-list</S.MyScheduleList>;
+};
+
+export default MyScheduleList;
+
+const S = {
+  MyScheduleList: styled.div`
+    width: 544px;
+    height: 470px;
+    border: 1px solid black;
+  `,
+};

--- a/src/pages/lobby/components/quick-button.tsx
+++ b/src/pages/lobby/components/quick-button.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+
+interface QuickButtonProps {
+  children: ReactNode;
+  onClick?: () => void;
+}
+
+const QuickButton: React.FC<QuickButtonProps> = ({ children, onClick }) => {
+  return <S.QuickButton onClick={onClick}>{children}</S.QuickButton>;
+};
+
+export default QuickButton;
+
+const S = {
+  QuickButton: styled.button`
+    width: 229px;
+    height: 229px;
+    border: 1px solid black;
+  `,
+};

--- a/src/pages/lobby/hooks/use-outside-click.ts
+++ b/src/pages/lobby/hooks/use-outside-click.ts
@@ -1,0 +1,16 @@
+import { useEffect, RefObject } from 'react';
+
+type RefType = RefObject<HTMLElement>;
+
+const useOutsideClick = (ref: RefType, callback: () => void) => {
+  useEffect(() => {
+    const handleOutSectionClick = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (ref.current && !ref.current.contains(target)) callback();
+    };
+    document.addEventListener('click', handleOutSectionClick);
+    return () => document.removeEventListener('click', handleOutSectionClick);
+  }, [ref, callback]);
+};
+
+export default useOutsideClick;

--- a/src/pages/lobby/hooks/use-outside-click.ts
+++ b/src/pages/lobby/hooks/use-outside-click.ts
@@ -1,6 +1,8 @@
-import { useEffect, RefObject } from 'react';
+import { useEffect } from 'react';
 
-type RefType = RefObject<HTMLElement>;
+interface RefType {
+  current: HTMLElement | null;
+}
 
 const useOutsideClick = (ref: RefType, callback: () => void) => {
   useEffect(() => {

--- a/src/pages/lobby/index.tsx
+++ b/src/pages/lobby/index.tsx
@@ -1,5 +1,44 @@
+import styled from 'styled-components';
+import DropdownButton from './components/dropdown-button';
+import MyCalendar from './components/my-calendar';
+import MyScheduleList from './components/my-schedule-list';
+import QuickButton from './components/quick-button';
+
 const Lobby = () => {
-  return <div>Lobby입니다!</div>;
+  return (
+    <S.LobbyPageWrapper>
+      <S.QuickButtonBox>
+        <DropdownButton>회의 생성</DropdownButton>
+        <QuickButton>내 정보</QuickButton>
+      </S.QuickButtonBox>
+      <S.MyScheduleBox>
+        <MyCalendar />
+        <MyScheduleList />
+      </S.MyScheduleBox>
+    </S.LobbyPageWrapper>
+  );
 };
 
 export default Lobby;
+
+const S = {
+  LobbyPageWrapper: styled.div`
+    border: 1px solid black;
+    margin: 76px 0 0 360px; // nav, side 가정
+    padding: 20px;
+    display: flex;
+  `,
+  QuickButtonBox: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 50px;
+    flex-grow: 3;
+    border: 1px solid black;
+  `,
+  MyScheduleBox: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  `,
+};

--- a/src/pages/lobby/index.tsx
+++ b/src/pages/lobby/index.tsx
@@ -24,7 +24,7 @@ export default Lobby;
 const S = {
   LobbyPageWrapper: styled.div`
     border: 1px solid black;
-    margin: 76px 0 0 360px; // nav, side 가정
+    /* margin: 76px 0 0 360px; // nav, side 가정 */
     padding: 20px;
     display: flex;
   `,


### PR DESCRIPTION
## 🚀 작업 내용

- 로비 페이지 UI 구현
- 퀵버튼, 드랍다운버튼, 내달력, 내 스케쥴 컴포넌트 분리
- useOutsideClick 커스텀 훅 구현

## 📝 참고 사항

- 로비 전체 스타일에 nav, side 가로세로폭 만큼 margin 값이 들어가 있는 상태입니다. 머지 후 필요부분 수정하도록 하겠습니다.
- 드랍다운 리스트가 열려있을 때 바깥 쪽 영역을 클릭하면 닫힐 수 있도록 useOutsideClick 커스텀훅을 추가하였습니다.
- 리액트 캘린더 라이브러리를 설치하여 기본스타일로 적용시켜 놓았고, 클릭 시 선택된 date 객체를 관리할 수 있도록 state 연결만 해둔 상태입니다.

## 🖼️ 스크린샷

https://github.com/part4-project/project-front/assets/128225030/58788d5d-6272-4a81-98f9-c9ba00770345




## 🚨 관련 이슈

- close #13 

