### PR TITLE
fix: lobby 페이지 및 하위 컴포넌트  height 값 수정

### DIFF
--- a/src/pages/lobby/components/my-calendar.tsx
+++ b/src/pages/lobby/components/my-calendar.tsx
@@ -41,7 +41,7 @@ export default MyCalendar;
 const S = {
   MyCalender: styled.div`
     width: 100%;
-    height: 400px;
+    height: 100%;
     border: 1px solid black;
 
     // 전체 캘린더
@@ -70,7 +70,7 @@ const S = {
     // 일자 타일 커스텀
     .react-calendar__tile {
       font-size: 16px;
-      padding: 15px;
+      padding: 20px;
       position: relative;
     }
 

--- a/src/pages/lobby/components/my-schedule-list.tsx
+++ b/src/pages/lobby/components/my-schedule-list.tsx
@@ -32,7 +32,7 @@ export default MyScheduleList;
 const S = {
   MyScheduleList: styled.div`
     width: 100%;
-    height: 470px;
+    height: 100%;
     border: 1px solid black;
   `,
 };

--- a/src/pages/lobby/index.tsx
+++ b/src/pages/lobby/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import UserInfoModal from '@components/modal/user-info-modal';
+import { navBarHeight } from '@styles/subsection-size';
 import styled from 'styled-components';
 import DropdownButton from './components/dropdown-button';
 import MyCalendar from './components/my-calendar';
@@ -34,6 +35,7 @@ const S = {
     border: 1px solid black;
     padding: 20px;
     display: flex;
+    height: calc(100vh - ${navBarHeight.desktop});
   `,
   QuickButtonBox: styled.div`
     width: 70%;


### PR DESCRIPTION
## 🚀 작업 내용

- 로비페이지 전체 height를 `calc(100vh - ${navBarHeight.desktop})` 로 수정하여 비율을 수정하여 스크롤 삭제하였습니다.

## 📝 참고 사항

- 

## 🖼️ 스크린샷
<img width="1664" alt="스크린샷 2024-05-31 오후 2 58 29" src="https://github.com/part4-project/effi_frontend/assets/128225030/c1dd94ea-69b0-4933-987e-109c5411c90e">



## 🚨 관련 이슈

- 
