### PR TITLE
유저정보api 세팅 및 axios인터셉터 설정

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -10,13 +10,35 @@ const instance = axios.create({
 instance.interceptors.request.use(
   (config) => {
     const token = getCookie('accessToken');
-
-    config.headers['Authorization'] = `Bearer ${token}`;
-
-    return config;
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+      return config;
+    } else {
+      window.location.href = '/login';
+      return config;
+    }
   },
   (error) => {
-    return Promise.reject(error);
+    if (error.response.status === 401) {
+      window.location.href = '/login';
+    }
+  },
+);
+instance.interceptors.response.use(
+  (config) => {
+    const token = getCookie('accessToken');
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+      return config;
+    } else {
+      window.location.href = '/login';
+      return config;
+    }
+  },
+  (error) => {
+    if (error.response.status === 401) {
+      window.location.href = '/login';
+    }
   },
 );
 

--- a/src/api/user/user-request.ts
+++ b/src/api/user/user-request.ts
@@ -1,9 +1,17 @@
 import axios from '@api/axios';
 
 const userRequest = {
+  FetchUserData: async () => {
+    try {
+      const { data } = await axios.get(`user/info/me`);
+      return data;
+    } catch (error) {
+      return error;
+    }
+  },
   updateNickname: async (nickName: string) => {
     try {
-      const { data } = await axios.post('user/info/modifyNickname', { nickName });
+      const { data } = await axios.post('user/info/modifyNickname', { nickname: nickName });
       return data;
     } catch (error) {
       return error;

--- a/src/hooks/react-query/use-query-user.ts
+++ b/src/hooks/react-query/use-query-user.ts
@@ -1,6 +1,14 @@
 /* eslint-disable no-console */
 import userRequest from '@api/user/user-request';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export const useUserQuery = () => {
+  const query = useQuery({
+    queryKey: [`userInfo`],
+    queryFn: async () => await userRequest.FetchUserData(),
+  });
+  return query;
+};
 
 export const useUserNicknameUpdateMutation = () => {
   const queryClient = useQueryClient();

--- a/src/pages/nav-bar/components/profile.tsx
+++ b/src/pages/nav-bar/components/profile.tsx
@@ -1,14 +1,29 @@
-import TestImg from '@assets/profile-test-img.gif';
+import { useEffect } from 'react';
 import ProfileModalButton from '@components/modal/profile-modal/profile-modal-button';
+import { useUserNicknameUpdateMutation, useUserQuery } from '@hooks/react-query/use-query-user';
+import { createRandomNickName } from '@utils/createRandomNickname';
 import styled from 'styled-components';
 
 const Profile = () => {
+  const { data: userData, isLoading, isError, isSuccess } = useUserQuery();
+  const { mutateAsync } = useUserNicknameUpdateMutation();
+
+  useEffect(() => {
+    if (isSuccess && userData?.nickname.length === 0) {
+      mutateAsync(createRandomNickName());
+    }
+  }, [isSuccess, userData, mutateAsync]);
+
+  if (isLoading) return 'Loading...';
+
+  if (isError) return 'Error...';
+
   return (
     <ProfileModalButton>
       <S.ProfileBox>
-        <S.NickNameBox>홍길동</S.NickNameBox>
+        <S.NickNameBox>{userData.nickname}</S.NickNameBox>
         <S.ProfileImgBox>
-          <img src={TestImg} alt="test" />
+          <img src={userData.profileImageUrl} alt="test" />
         </S.ProfileImgBox>
       </S.ProfileBox>
     </ProfileModalButton>


### PR DESCRIPTION
## 🚀 작업 내용
- 유저정보 조회api 및 axios 인터셉터 설정
- 요청 및 응답 시 토큰 없으면 /login으로 보내고 401에러 발생 시 /login으로 보냅니다 

## 📝 참고 사항
- navBar에 유저정보조회api 예제 만들어놨습니다 참고하시면 될 거 같아요

## 🖼️ 스크린샷
<img width="372" alt="스크린샷 2024-06-12 오후 10 55 04" src="https://github.com/part4-project/effi_frontend/assets/51107943/7bfa8571-c3d1-4710-ac1b-1a90d09c7d20">


## 🚨 관련 이슈
- close #122 
