### PR TITLE
프로필 이미지 업데이트, 기본이미지 프로필 api 연동 완료

### DIFF
--- a/src/components/modal/profile-modal/profile-image-input.tsx
+++ b/src/components/modal/profile-modal/profile-image-input.tsx
@@ -9,7 +9,9 @@ import styled from 'styled-components';
 
 const ProfileImageInput = () => {
   const {
-    data: { profileImageUrl, isLoading, isError },
+    data: { profileImageUrl },
+    isLoading,
+    isError,
   } = useUserQuery();
   const { mutate: profileImgUpdateMutate, isPending: isProfileImgUpdatePending } = useUserProfileImgUpdateMutation();
   const { mutate: defaultImgMutate, isPending: isDefaultImgPending } = useUserProfileImgDefaultMutation();

--- a/src/components/modal/profile-modal/profile-image-input.tsx
+++ b/src/components/modal/profile-modal/profile-image-input.tsx
@@ -1,24 +1,48 @@
-import { ChangeEvent, useState } from 'react';
-import { USER } from '@constants/mockdata';
+import { ChangeEvent } from 'react';
+import refreshIcon from '@assets/icons/refresh.svg';
+import {
+  useUserProfileImgDefaultMutation,
+  useUserProfileImgUpdateMutation,
+  useUserQuery,
+} from '@hooks/react-query/use-query-user';
 import styled from 'styled-components';
 
 const ProfileImageInput = () => {
-  const [imgSrc, setImgSrc] = useState(USER.profile_img);
+  const {
+    data: { profileImageUrl, isLoading, isError },
+  } = useUserQuery();
+  const { mutate: profileImgUpdateMutate, isPending: isProfileImgUpdatePending } = useUserProfileImgUpdateMutation();
+  const { mutate: defaultImgMutate, isPending: isDefaultImgPending } = useUserProfileImgDefaultMutation();
 
   const handleImgInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
-      const imageSrc = URL.createObjectURL(e.target.files[0]);
-      setImgSrc(imageSrc);
+      const file = e.target.files[0];
+      profileImgUpdateMutate(file);
     }
   };
+
+  const handleDefaultImgButtonClick = () => {
+    defaultImgMutate();
+  };
+
+  if (isLoading) return 'Loading...';
+
+  if (isError) return 'Error...';
 
   return (
     <S.Container>
       <S.ProfileImgInputWrapper>
-        <S.ProfileImgInputLabel htmlFor="imgInput" />
-        <S.ProfileImgInput type="file" id="imgInput" accept=".jpg, .jpeg, .png, .svg" onChange={handleImgInputChange} />
-        <S.ProfileImg src={imgSrc} alt="Profile Image" />
+        <S.ProfileImgInputLabel $isPending={isProfileImgUpdatePending || isDefaultImgPending} htmlFor="imgInput" />
+        <S.ProfileImgInput
+          type="file"
+          id="imgInput"
+          accept=".jpg, .jpeg, .png, .svg"
+          onChange={handleImgInputChange}
+          disabled={isProfileImgUpdatePending || isDefaultImgPending}
+        />
+        <S.ProfileImg src={profileImageUrl} alt="Profile Image" />
       </S.ProfileImgInputWrapper>
+      <S.DefaultImgButton src={refreshIcon} alt="기본 이미지 버튼" onClick={handleDefaultImgButtonClick} />
     </S.Container>
   );
 };
@@ -30,6 +54,7 @@ const S = {
     display: flex;
     justify-content: center;
     margin: 10px 0 40px;
+    position: relative;
   `,
 
   ProfileImgInputWrapper: styled.div`
@@ -45,14 +70,14 @@ const S = {
     position: relative;
   `,
 
-  ProfileImgInputLabel: styled.label`
+  ProfileImgInputLabel: styled.label<{ $isPending: boolean }>`
     width: 168px;
     height: 168px;
     display: flex;
     justify-content: center;
     align-items: center;
     font-size: 50px;
-    cursor: pointer;
+    cursor: ${({ $isPending }) => ($isPending ? 'not-allowed' : 'pointer')};
     position: absolute;
   `,
 
@@ -67,5 +92,14 @@ const S = {
     width: 168px;
     height: 168px;
     pointer-events: none;
+  `,
+  DefaultImgButton: styled.img`
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+    position: absolute;
+    bottom: 0;
+    left: 60%;
+    transform: translateX(-60%);
   `,
 };

--- a/src/hooks/react-query/use-query-user.ts
+++ b/src/hooks/react-query/use-query-user.ts
@@ -32,7 +32,7 @@ export const useUserProfileImgUpdateMutation = () => {
     mutationFn: async (userData: File) => await userRequest.updateProfileImg(userData),
     onSuccess: () => {
       // Invalidate and refetch
-      queryClient.invalidateQueries({ queryKey: [`userProfileImg`] });
+      queryClient.invalidateQueries({ queryKey: [`userInfo`] });
     },
     onError: (error) => console.log(`유저 프로필사진 변경 에러: ${error}`),
   });
@@ -47,7 +47,7 @@ export const useUserProfileImgDefaultMutation = () => {
     mutationFn: async () => await userRequest.updateProfileDefaultImg(),
     onSuccess: () => {
       // Invalidate and refetch
-      queryClient.invalidateQueries({ queryKey: [`userProfileImg`] });
+      queryClient.invalidateQueries({ queryKey: [`userInfo`] });
     },
     onError: (error) => console.log(`유저 프로필사진(기본) 변경 에러: ${error}`),
   });


### PR DESCRIPTION
## 🚀 작업 내용
- profileupdate 및 기본이미지변경 api 적용
- profileImg 변경되면 userInfo update되게 쿼리키 userInfo 로 통일(한번에 업데이트 되게끔)

## 📝 참고 사항
- profileImg 바뀌면 userInfo가 refetch되게 key값 userInfo로 통일했는데 괜찮을까요??
- 기본이미지 변경 버튼은 임시로 적용했습니다.

## 🖼️ 스크린샷
![image](https://github.com/part4-project/effi_frontend/assets/107683008/b0673f2b-db47-4517-a523-4f9372a96b13)



## 🚨 관련 이슈

- 
