### PR TITLE
닉네임 api 에러 처리, 토스트 에러 시 색상 변경

### DIFF
--- a/src/api/user/user-request.ts
+++ b/src/api/user/user-request.ts
@@ -14,7 +14,7 @@ const userRequest = {
       const { data } = await axios.post('user/info/modifyNickname', { nickname: nickName });
       return data;
     } catch (error) {
-      return error;
+      throw new Error(error as string);
     }
   },
   updateProfileImg: async (file: File) => {

--- a/src/components/modal/profile-modal/nickname-input.tsx
+++ b/src/components/modal/profile-modal/nickname-input.tsx
@@ -24,7 +24,7 @@ const NicknameInput = () => {
         toast('닉네임이 저장 되었습니다.');
       },
       onError: () => {
-        toast('닉네임 저장에 실패했습니다.');
+        toast('닉네임 변경에 실패했습니다.', true);
       },
     });
   };

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -5,14 +5,19 @@ import styled from 'styled-components';
 interface TToastProps {
   children: ReactNode;
   show: boolean;
+  error: boolean;
 }
 
-function Toast({ children, show }: TToastProps) {
-  return <S.Container $show={show}>{children}</S.Container>;
+function Toast({ children, show, error }: TToastProps) {
+  return (
+    <S.Container $show={show} $error={error}>
+      {children}
+    </S.Container>
+  );
 }
 
 const S = {
-  Container: styled.div<{ $show: boolean }>`
+  Container: styled.div<{ $show: boolean; $error: boolean }>`
     position: fixed;
     left: 50%;
     top: 70px;
@@ -20,7 +25,7 @@ const S = {
     display: ${({ $show }) => ($show ? 'flex' : 'none')};
     align-items: center;
     justify-content: center;
-    background-color: var(--blue05);
+    background-color: ${({ $error }) => ($error ? 'var(--red01)' : 'var(--blue05)')};
     color: var(--white);
     opacity: 0.8;
     width: 364px;

--- a/src/components/toast/toaster.tsx
+++ b/src/components/toast/toaster.tsx
@@ -8,7 +8,7 @@ const Toaster = () => {
     <>
       {toasts.map((toast) => {
         return (
-          <Toast key={toast.id} show={toast.show}>
+          <Toast key={toast.id} show={toast.show} error={toast.error}>
             {toast.message}
           </Toast>
         );

--- a/src/hooks/react-query/use-query-user.ts
+++ b/src/hooks/react-query/use-query-user.ts
@@ -20,7 +20,7 @@ export const useUserNicknameUpdateMutation = () => {
       queryClient.invalidateQueries({ queryKey: [`userInfo`] });
       queryClient.refetchQueries({ queryKey: [`groupInfo`] });
     },
-    onError: (error) => console.log(`유저 이름변경 에러: ${error}`),
+    onError: (error) => console.error(`유저 이름변경 에러: ${error}`),
   });
 
   return mutation;

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -7,6 +7,7 @@ interface Toast {
   id: string;
   message: string;
   show: boolean;
+  error: boolean;
 }
 
 let toasts: Toast[] = [];
@@ -21,12 +22,12 @@ const timeouts = new Map<string, ReturnType<typeof setTimeout>>();
 // eslint-disable-next-line no-unused-vars
 const listeners: Array<(toasts: Toast[]) => void> = [];
 
-const toast = (message: string) => {
+const toast = (message: string, isError: boolean = false) => {
   const id = genId();
 
   listeners.forEach((listener) => {
     if (!toasts.find((toast) => toast.id === id)) {
-      toasts = [...toasts, { id, message, show: true }];
+      toasts = [...toasts, { id, message, show: true, error: isError }];
     }
     listener(toasts);
 
@@ -50,7 +51,6 @@ const toast = (message: string) => {
 
 export const useToast = () => {
   const [state, setState] = useState(toasts);
-
   useEffect(() => {
     listeners.push(setState);
     return () => {


### PR DESCRIPTION
## 🚀 작업 내용

- 닉네임 api 에러시 '닉네임 변경에 실패했습니다.' 토스트 띄우기
- 토스트 함수 두 번째 인수에 true를 입력할 시 토스트 배경이 빨간색으로 변함

## 📝 참고 사항

- 에러시 console.log()에서 console.error()로 바꿨습니다.

## 🖼️ 스크린샷
![스크린샷 2024-06-14 165811](https://github.com/part4-project/effi_frontend/assets/55544307/b1449899-14a5-4605-b51b-803ebd8a0dae)


## 🚨 관련 이슈

- #135 
