### PR TITLE
각 api 에러핸들링 컨벤션 추가 및 모든 뮤테이션 코드 리펙토링

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,6 +1,12 @@
 import { getCookie } from '@utils/cookie';
 import axios from 'axios';
 
+export interface TAxiosError {
+  errorMessage: string;
+  errorCode: string;
+  statusCode: number;
+}
+
 const instance = axios.create({
   baseURL: 'https://api.effi.club/',
   timeout: 5000,
@@ -22,6 +28,7 @@ instance.interceptors.request.use(
     if (error.response.status === 401) {
       window.location.href = '/login';
     }
+    return error;
   },
 );
 instance.interceptors.response.use(
@@ -36,6 +43,7 @@ instance.interceptors.response.use(
     if (error.response.status === 401) {
       window.location.href = '/login';
     }
+    return error;
   },
 );
 

--- a/src/api/group/group-request.ts
+++ b/src/api/group/group-request.ts
@@ -1,4 +1,5 @@
 import axios from '@api/axios';
+import { isAxiosError } from 'axios';
 
 const groupRequest = {
   fetchGroup: async () => {
@@ -22,6 +23,15 @@ const groupRequest = {
       const { data } = await axios.post('user/group/create', { groupName: groupData });
       return data;
     } catch (error) {
+      if (isAxiosError(error)) {
+        if (error.response) {
+          throw {
+            errorMessage: error.response.data.errorMessage || 'errorMessage',
+            errorCode: error.response.data.errorCode || 'UNKNOWN_ERROR',
+            statusCode: error.response.status,
+          };
+        }
+      }
       return error;
     }
   },
@@ -30,14 +40,36 @@ const groupRequest = {
       const { data } = await axios.patch(`user/group/modify/${groupId}`, { groupName });
       return data;
     } catch (error) {
+      if (isAxiosError(error)) {
+        if (error.response) {
+          throw {
+            errorMessage: error.response.data.errorMessage || 'errorMessage',
+            errorCode: error.response.data.errorCode || 'UNKNOWN_ERROR',
+            statusCode: error.response.status,
+          };
+        }
+      }
       return error;
     }
   },
   inviteGroup: async (targetEmail: string, groupId: number) => {
     try {
-      const { data } = await axios.post(`user/group/invite`, { groupId, targetEmail });
-      return data;
+      const response = await axios.post(`user/group/invite`, { groupId, targetEmail });
+      if (response.status == 200) {
+        return response.data;
+      } else {
+        throw response;
+      }
     } catch (error) {
+      if (isAxiosError(error)) {
+        if (error.response) {
+          throw {
+            errorMessage: error.response.data.errorMessage || 'errorMessage',
+            errorCode: error.response.data.errorCode || 'UNKNOWN_ERROR',
+            statusCode: error.response.status,
+          };
+        }
+      }
       return error;
     }
   },
@@ -54,6 +86,15 @@ const groupRequest = {
       const { data } = await axios.post(`user/group/invitation/accept`, { groupId });
       return data;
     } catch (error) {
+      if (isAxiosError(error)) {
+        if (error.response) {
+          throw {
+            errorMessage: error.response.data.errorMessage || 'errorMessage',
+            errorCode: error.response.data.errorCode || 'UNKNOWN_ERROR',
+            statusCode: error.response.status,
+          };
+        }
+      }
       return error;
     }
   },
@@ -61,6 +102,15 @@ const groupRequest = {
     try {
       await axios.delete(`user/group/invitation/reject`, { data: { groupId } });
     } catch (error) {
+      if (isAxiosError(error)) {
+        if (error.response) {
+          throw {
+            errorMessage: error.response.data.errorMessage || 'errorMessage',
+            errorCode: error.response.data.errorCode || 'UNKNOWN_ERROR',
+            statusCode: error.response.status,
+          };
+        }
+      }
       return error;
     }
   },

--- a/src/api/group/group-request.type.ts
+++ b/src/api/group/group-request.type.ts
@@ -18,6 +18,7 @@ export interface TGroupFetchMemberInfo {
   admin: boolean;
 }
 export interface TGroupMemberFetchRes {
+  code: string;
   groupName: string;
   memberList: TGroupFetchMemberInfo[];
 }

--- a/src/api/meeting/meeting-request.ts
+++ b/src/api/meeting/meeting-request.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { isAxiosError } from 'axios';
 import { TMeetingCreateReq } from './meeting-request.type';
 
 const meetingRequest = {
@@ -7,6 +7,15 @@ const meetingRequest = {
       const { data } = await axios.post(`user/group/${groupId}/meeting/create`, meetingData);
       return data;
     } catch (error) {
+      if (isAxiosError(error)) {
+        if (error.response) {
+          throw {
+            errorMessage: error.response.data.errorMessage || 'errorMessage',
+            errorCode: error.response.data.errorCode || 'UNKNOWN_ERROR',
+            statusCode: error.response.status,
+          };
+        }
+      }
       return error;
     }
   },

--- a/src/api/user/user-request.ts
+++ b/src/api/user/user-request.ts
@@ -1,4 +1,5 @@
 import axios from '@api/axios';
+import { isAxiosError } from 'axios';
 
 const userRequest = {
   FetchUserData: async () => {
@@ -14,7 +15,16 @@ const userRequest = {
       const { data } = await axios.post('user/info/modifyNickname', { nickname: nickName });
       return data;
     } catch (error) {
-      throw new Error(error as string);
+      if (isAxiosError(error)) {
+        if (error.response) {
+          throw {
+            errorMessage: error.response.data.errorMessage || 'errorMessage',
+            errorCode: error.response.data.errorCode || 'UNKNOWN_ERROR',
+            statusCode: error.response.status,
+          };
+        }
+      }
+      return error;
     }
   },
   updateProfileImg: async (file: File) => {
@@ -29,6 +39,15 @@ const userRequest = {
       });
       return data;
     } catch (error) {
+      if (isAxiosError(error)) {
+        if (error.response) {
+          throw {
+            errorMessage: error.response.data.errorMessage || 'errorMessage',
+            errorCode: error.response.data.errorCode || 'UNKNOWN_ERROR',
+            statusCode: error.response.status,
+          };
+        }
+      }
       return error;
     }
   },
@@ -37,6 +56,15 @@ const userRequest = {
       const { data } = await axios.post(`user/info/modifyProfileImage/default`);
       return data;
     } catch (error) {
+      if (isAxiosError(error)) {
+        if (error.response) {
+          throw {
+            errorMessage: error.response.data.errorMessage || 'errorMessage',
+            errorCode: error.response.data.errorCode || 'UNKNOWN_ERROR',
+            statusCode: error.response.status,
+          };
+        }
+      }
       return error;
     }
   },

--- a/src/api/user/user-request.type.ts
+++ b/src/api/user/user-request.type.ts
@@ -1,6 +1,16 @@
 // request
 
 // response
+export interface TUserInfoRes {
+  id: number;
+  nickname: string;
+  email: string;
+  userState: string;
+  profileImageUrl: string;
+  isAdditionalProcess: boolean;
+  createdAt: string;
+  modifiedAt: string;
+}
 export interface TUserNicknameRes {
   id: number;
   nickname: string;

--- a/src/components/modal/profile-modal/nickname-input.tsx
+++ b/src/components/modal/profile-modal/nickname-input.tsx
@@ -1,7 +1,6 @@
 import { FormEvent, useEffect } from 'react';
 import refreshIcon from '@assets/icons/refresh.svg';
 import { useUserQuery, useUserNicknameUpdateMutation } from '@hooks/react-query/use-query-user';
-import { useToast } from '@hooks/use-toast';
 import useValidateText from '@hooks/use-validate-text';
 import { createRandomNickName } from '@utils/createRandomNickname';
 import styled, { css } from 'styled-components';
@@ -10,7 +9,6 @@ const NicknameInput = () => {
   const nickNameUpdate = useUserNicknameUpdateMutation();
   const { data: userData } = useUserQuery();
   const { inputValue, setInputValue, errorMessage, handleInputChange } = useValidateText(2, 7);
-  const { toast } = useToast();
 
   const handleNicknameRefreshButtonClick = () => {
     const newNickName = createRandomNickName();
@@ -19,14 +17,7 @@ const NicknameInput = () => {
 
   const handleNickNameSaveButtonClick = (e: FormEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    nickNameUpdate.mutate(inputValue, {
-      onSuccess: () => {
-        toast('닉네임이 저장 되었습니다.');
-      },
-      onError: () => {
-        toast('닉네임 변경에 실패했습니다.', true);
-      },
-    });
+    nickNameUpdate.mutate(inputValue);
   };
 
   useEffect(() => {

--- a/src/constants/query-key.ts
+++ b/src/constants/query-key.ts
@@ -1,0 +1,7 @@
+export const QUERY_KEY = {
+  groupInfo: 'groupInfo',
+  userInfo: 'userInfo',
+  groupList: 'groupList',
+  invitedGroupList: 'invitedGroupList',
+  meetingList: 'meetingList',
+} as const;

--- a/src/hooks/react-query/use-query-group.ts
+++ b/src/hooks/react-query/use-query-group.ts
@@ -1,11 +1,14 @@
 /* eslint-disable no-console */
+import { TAxiosError } from '@api/axios';
 import groupRequest from '@api/group/group-request';
 import { TInvitedGroupFetchRes } from '@api/group/group-request.type';
+import { QUERY_KEY } from '@constants/query-key';
+import { useToast } from '@hooks/use-toast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 export const useGroupQuery = () => {
   const query = useQuery({
-    queryKey: [`groupList`],
+    queryKey: [QUERY_KEY.groupList],
     queryFn: async () => await groupRequest.fetchGroup(),
   });
   return query;
@@ -13,38 +16,42 @@ export const useGroupQuery = () => {
 
 export const useGroupMemberQuery = (groupId: number) => {
   const query = useQuery({
-    queryKey: [`groupInfo`, groupId],
+    queryKey: [QUERY_KEY.groupInfo, groupId],
     queryFn: async () => await groupRequest.fetchGroupMember(groupId),
   });
   return query;
 };
 
 export const useGroupCreateMutation = () => {
+  const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async (groupData: string) => await groupRequest.createGroup(groupData),
     onSuccess: () => {
       // Invalidate and refetch
-      queryClient.invalidateQueries({ queryKey: [`groupList`] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.groupList] });
+      toast('그룹이 생성되었습니다');
     },
-    onError: (error) => console.log(`그룹 생성 에러: ${error}`),
+    onError: (error: TAxiosError) => toast(error.errorMessage),
   });
 
   return mutation;
 };
 
 export const useGroupUpdateMutation = (groupId: number) => {
+  const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async (groupName: string) => await groupRequest.updateGroup(groupName, groupId),
     onSuccess: () => {
       // Invalidate and refetch
-      queryClient.invalidateQueries({ queryKey: [`groupInfo`, groupId] });
-      queryClient.invalidateQueries({ queryKey: [`groupList`] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.groupInfo, groupId] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.groupList] });
+      toast('그룹명이 변경되었습니다');
     },
-    onError: (error) => console.log(`그룹명 수정 에러: ${error}`),
+    onError: (error: TAxiosError) => toast(error.errorMessage),
   });
 
   return mutation;
@@ -52,48 +59,55 @@ export const useGroupUpdateMutation = (groupId: number) => {
 
 export const useInvitedGroupQuery = () => {
   const query = useQuery<TInvitedGroupFetchRes[], Error>({
-    queryKey: [`invitedGroupList`],
+    queryKey: [QUERY_KEY.invitedGroupList],
     queryFn: async () => await groupRequest.fetchInvitedGroup(),
   });
   return query;
 };
 
 export const useInvitedGroupAcceptMutation = () => {
+  const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async (groupId: number) => await groupRequest.acceptInvitedGroup(groupId),
     onSuccess: () => {
       // Invalidate and refetch
-      queryClient.invalidateQueries({ queryKey: [`invitedGroupList`] });
-      queryClient.invalidateQueries({ queryKey: [`groupList`] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.invitedGroupList] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.groupList] });
+      toast('초대가 수락되었습니다');
     },
-    onError: (error) => console.log(`그룹 초대 수락 에러: ${error}`),
+    onError: (error: TAxiosError) => toast(error.errorMessage),
   });
 
   return mutation;
 };
 
 export const useInvitedGroupRejectMutation = () => {
+  const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async (groupId: number) => await groupRequest.rejectInvitedGroup(groupId),
     onSuccess: () => {
       // Invalidate and refetch
-      queryClient.invalidateQueries({ queryKey: [`invitedGroupList`] });
-      queryClient.invalidateQueries({ queryKey: [`groupList`] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.invitedGroupList] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.groupList] });
+      toast('초대를 거절했습니다');
     },
-    onError: (error) => console.log(`그룹 초대 거절 에러: ${error}`),
+    onError: (error: TAxiosError) => toast(error.errorMessage),
   });
 
   return mutation;
 };
 
 export const useGroupInviteMutation = (groupId: number) => {
+  const { toast } = useToast();
+
   const mutation = useMutation({
     mutationFn: async (targetEmail: string) => await groupRequest.inviteGroup(targetEmail, groupId),
-    onError: (error) => console.log(`그룹초대 에러: ${error.message}`),
+    onSuccess: () => toast('초대가 완료되었습니다'),
+    onError: (error: TAxiosError) => toast(error.errorMessage),
   });
   return mutation;
 };

--- a/src/hooks/react-query/use-query-meeting.ts
+++ b/src/hooks/react-query/use-query-meeting.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import meetingRequest from '@api/meeting/meeting-request';
 import { TMeetingCreateReq } from '@api/meeting/meeting-request.type';
+import { QUERY_KEY } from '@constants/query-key';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useMeetingCreateMutation = (groupId: number) => {
@@ -10,9 +11,9 @@ export const useMeetingCreateMutation = (groupId: number) => {
     mutationFn: async (meetingData: TMeetingCreateReq) => await meetingRequest.createMeeting(meetingData, groupId),
     onSuccess: () => {
       // Invalidate and refetch
-      queryClient.invalidateQueries({ queryKey: [`meetingList`, groupId] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.meetingList, groupId] });
     },
-    onError: (error) => console.log(`회의 생성 에러: ${error}`),
+    onError: (error) => console.error(`회의 생성 에러: ${error}`),
   });
 
   return mutation;

--- a/src/hooks/react-query/use-query-user.ts
+++ b/src/hooks/react-query/use-query-user.ts
@@ -1,56 +1,65 @@
 /* eslint-disable no-console */
+import { TAxiosError } from '@api/axios';
 import userRequest from '@api/user/user-request';
+import { QUERY_KEY } from '@constants/query-key';
+import { useToast } from '@hooks/use-toast';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 export const useUserQuery = () => {
   const query = useQuery({
-    queryKey: [`userInfo`],
+    queryKey: [QUERY_KEY.userInfo],
     queryFn: async () => await userRequest.FetchUserData(),
   });
   return query;
 };
 
 export const useUserNicknameUpdateMutation = () => {
+  const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async (nickName: string) => await userRequest.updateNickname(nickName),
     onSuccess: () => {
       // Invalidate and refetch
-      queryClient.invalidateQueries({ queryKey: [`userInfo`] });
-      queryClient.refetchQueries({ queryKey: [`groupInfo`] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.userInfo] });
+      queryClient.refetchQueries({ queryKey: [QUERY_KEY.groupInfo] });
+      toast('닉네임이 변경되었습니다');
     },
-    onError: (error) => console.error(`유저 이름변경 에러: ${error}`),
+    onError: (error: TAxiosError) => toast(error.errorMessage),
   });
 
   return mutation;
 };
 
 export const useUserProfileImgUpdateMutation = () => {
+  const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async (userData: File) => await userRequest.updateProfileImg(userData),
     onSuccess: () => {
       // Invalidate and refetch
-      queryClient.invalidateQueries({ queryKey: [`userInfo`] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.userInfo] });
+      toast('프로필이미지가 변경되었습니다');
     },
-    onError: (error) => console.log(`유저 프로필사진 변경 에러: ${error}`),
+    onError: (error: TAxiosError) => toast(error.errorMessage),
   });
 
   return mutation;
 };
 
 export const useUserProfileImgDefaultMutation = () => {
+  const { toast } = useToast();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async () => await userRequest.updateProfileDefaultImg(),
     onSuccess: () => {
       // Invalidate and refetch
-      queryClient.invalidateQueries({ queryKey: [`userInfo`] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.userInfo] });
+      toast('프로필이미지가 초기화 되었습니다');
     },
-    onError: (error) => console.log(`유저 프로필사진(기본) 변경 에러: ${error}`),
+    onError: (error: TAxiosError) => toast(error.errorMessage),
   });
 
   return mutation;

--- a/src/pages/group-home/components/group-modal/group-invite.tsx
+++ b/src/pages/group-home/components/group-modal/group-invite.tsx
@@ -1,18 +1,15 @@
 import { MouseEvent, useRef } from 'react';
 import { useGroupInviteMutation } from '@hooks/react-query/use-query-group';
-import { useToast } from '@hooks/use-toast';
 import { useGroupStore } from '@stores/group';
 import styled from 'styled-components';
 
 const GroupInvite = () => {
-  const { mutateAsync } = useGroupInviteMutation(useGroupStore((state) => state.groupId));
+  const { mutate } = useGroupInviteMutation(useGroupStore((state) => state.groupId));
   const emailRef = useRef<HTMLInputElement>(null);
-  const { toast } = useToast();
-  const handleSubmitBtnClick = async (e: MouseEvent<HTMLButtonElement>) => {
+  const handleSubmitBtnClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     if (emailRef.current) {
-      await mutateAsync(emailRef.current.value);
-      toast('초대가 완료되었습니다');
+      mutate(emailRef.current.value);
     }
   };
 

--- a/src/pages/group-home/components/group-modal/group-member-info.tsx
+++ b/src/pages/group-home/components/group-modal/group-member-info.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import { TGroupFetchMemberInfo } from '@api/group/group-request.type';
+import groupLeaderBadge from '@assets/icons/group-leader-badge.svg';
 import styled from 'styled-components';
 
-const GroupMemberInfo: React.FC<TGroupFetchMemberInfo> = ({ nickname, email }) => {
+const GroupMemberInfo: React.FC<TGroupFetchMemberInfo> = ({ nickname, email, admin }) => {
   const [isExport, setIsExport] = useState<boolean>(false);
   const exportName = isExport ? '내보내기 취소' : '내보내기';
 
@@ -16,9 +17,15 @@ const GroupMemberInfo: React.FC<TGroupFetchMemberInfo> = ({ nickname, email }) =
         <S.MemberName $isExport={isExport}>{nickname}</S.MemberName>
         <S.MemberEmail>{email}</S.MemberEmail>
       </S.MemberInfo>
-      <S.MemberExportBtn $isExport={isExport} onClick={handleExportClick}>
-        {exportName}
-      </S.MemberExportBtn>
+      {admin ? (
+        <S.AdminIconBox>
+          <S.AdminIcon src={groupLeaderBadge} alt="admin" />
+        </S.AdminIconBox>
+      ) : (
+        <S.MemberExportBtn $isExport={isExport} onClick={handleExportClick}>
+          {exportName}
+        </S.MemberExportBtn>
+      )}
     </S.MemberInfoWrap>
   );
 };
@@ -35,6 +42,12 @@ const S = {
     &:last-child {
       border-bottom: 0;
     }
+  `,
+  AdminIconBox: styled.div`
+    padding: 10px;
+  `,
+  AdminIcon: styled.img`
+    width: 14px;
   `,
   MemberInfo: styled.div`
     display: flex;

--- a/src/pages/group-home/components/sidebar/group-home-sidebar.tsx
+++ b/src/pages/group-home/components/sidebar/group-home-sidebar.tsx
@@ -1,8 +1,9 @@
-import { TGroupFetchMemberInfo } from '@api/group/group-request.type';
+import { TGroupFetchMemberInfo, TGroupMemberFetchRes } from '@api/group/group-request.type';
 import groupLeaderBadge from '@assets/icons/group-leader-badge.svg';
-import { useGroupMemberQuery } from '@hooks/react-query/use-query-group';
+import { QUERY_KEY } from '@constants/query-key';
 import GroupNameInput from '@pages/group-home/components/sidebar/group-name-input';
 import { useGroupStore } from '@stores/group';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -11,21 +12,22 @@ interface TGroupHomeSideBarProps {
 }
 
 const GroupHomeSideBar = ({ isAdmin }: TGroupHomeSideBarProps) => {
-  const { data: groupData, isError, isLoading } = useGroupMemberQuery(useGroupStore((state) => state.groupId));
+  const groupData = useQueryClient().getQueryData<TGroupMemberFetchRes>([
+    QUERY_KEY.groupInfo,
+    useGroupStore((state) => state.groupId),
+  ]);
   const navigate = useNavigate();
+
   const handleLeaveGroupButtonClick = () => {
     navigate('/');
   };
 
-  if (isLoading) return 'Loading...';
-  if (isError) return 'Error...';
-
   return (
     <S.Container>
-      <GroupNameInput groupName={groupData.groupName} groupCode={groupData.code} isAdmin={isAdmin} />
+      <GroupNameInput groupName={groupData!.groupName} groupCode={groupData!.code} isAdmin={isAdmin} />
 
       <S.GroupMemberLists>
-        {groupData.memberList.map((member: TGroupFetchMemberInfo) => (
+        {groupData!.memberList.map((member: TGroupFetchMemberInfo) => (
           <S.GroupMemberList key={member.id}>
             <span>{member.nickname}</span>
             {member.admin && <S.AdminIcon src={groupLeaderBadge} />}

--- a/src/pages/group-home/index.tsx
+++ b/src/pages/group-home/index.tsx
@@ -1,17 +1,30 @@
+import { TGroupFetchMemberInfo } from '@api/group/group-request.type';
+import { TUserInfoRes } from '@api/user/user-request.type';
 import { MY_SCHEDULE_LIST } from '@constants/mockdata';
+import { QUERY_KEY } from '@constants/query-key';
+import { useGroupMemberQuery } from '@hooks/react-query/use-query-group';
 import GroupHomeHeader from '@pages/group-home/components/group-home-header';
 import MeetingNotes from '@pages/group-home/components/meeting-notes';
 import Meetings from '@pages/group-home/components/meetings';
 import GroupHomeSideBar from '@pages/group-home/components/sidebar/group-home-sidebar';
+import { useGroupStore } from '@stores/group';
 import { device } from '@styles/breakpoints';
 import { navBarHeight } from '@styles/subsection-size';
+import { useQueryClient } from '@tanstack/react-query';
 import styled from 'styled-components';
 import AdminHOC from './components/admin-hoc';
 
 const GroupHome = () => {
+  const { data: groupData, isError, isLoading } = useGroupMemberQuery(useGroupStore((state) => state.groupId));
+  const userInfo = useQueryClient().getQueryData<TUserInfoRes>([QUERY_KEY.userInfo]);
+
+  if (isLoading) return 'Loading...';
+  if (isError) return 'Error...';
+
   const scheduledMeeting = MY_SCHEDULE_LIST[0];
   const isOnLive = true;
-  const isAdmin = true;
+  const { id: adminId } = groupData.memberList.find((data: TGroupFetchMemberInfo) => data.admin);
+  const isAdmin = adminId == userInfo?.id;
 
   return (
     <S.Container>
@@ -36,7 +49,7 @@ const S = {
   GroupHomeMain: styled.div`
     width: 100%;
     height: calc(100vh - ${navBarHeight.desktop});
-    padding: 80px 80px 60px;
+    padding: 80px 80px 20px;
     overflow: hidden;
     display: flex;
     flex-direction: column;

--- a/src/pages/nav-bar/components/alarm.tsx
+++ b/src/pages/nav-bar/components/alarm.tsx
@@ -24,6 +24,7 @@ const S = {
     display: flex;
     align-items: center;
     justify-content: center;
+    cursor: pointer;
   `,
   AlarmImg: styled.img`
     height: initial;

--- a/src/pages/side-bar/components/group-item.tsx
+++ b/src/pages/side-bar/components/group-item.tsx
@@ -49,6 +49,7 @@ export default GroupItem;
 
 const S = {
   GroupItem: styled.div<{ $isSelect: boolean }>`
+    cursor: pointer;
     position: relative;
     border-radius: 10px;
     overflow: hidden;

--- a/src/pages/side-bar/components/modal/group-create-modal-button.tsx
+++ b/src/pages/side-bar/components/modal/group-create-modal-button.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useGroupCreateMutation } from '@hooks/react-query/use-query-group';
-import { useToast } from '@hooks/use-toast';
 import GroupCreateModal from '@pages/side-bar/components/modal/group-create-modal';
 
 interface GroupCreateModalButtonProps {
@@ -9,7 +8,6 @@ interface GroupCreateModalButtonProps {
 
 const GroupCreateModalButton = ({ children }: GroupCreateModalButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { toast } = useToast();
   const { mutateAsync } = useGroupCreateMutation();
 
   const handleModalClose = () => {
@@ -22,16 +20,7 @@ const GroupCreateModalButton = ({ children }: GroupCreateModalButtonProps) => {
 
   const handleSubmitBtnClick = async (groupName: string | undefined) => {
     if (groupName) {
-      try {
-        await mutateAsync(groupName);
-        toast('그룹이 생성되었습니다.');
-        setIsOpen(false);
-      } catch (error) {
-        toast('그룹 생성에 실패했습니다.');
-        setIsOpen(false);
-      }
-    } else {
-      toast('그룹 이름을 입력하세요.');
+      await mutateAsync(groupName);
       setIsOpen(false);
     }
   };


### PR DESCRIPTION
## 🚀 작업 내용
- api 에러핸들링
- 기존 적용되어 있던 뮤테이션 코드 리펙토링(에러핸들링 추가)
- 쿼리키 전역상수화

## 📝 참고 사항
- 그룹api뿐아니라 다른 api에도 에러핸들링을 적용해놨습니다
- 쿼리키는 전역상수화해서 관리되도록 수정했습니다

## 🖼️ 스크린샷
<img width="734" alt="스크린샷 2024-06-15 오후 8 31 01" src="https://github.com/part4-project/effi_frontend/assets/51107943/a4458f39-ab05-4d04-a20c-d7ea27fefa39">
<img width="633" alt="스크린샷 2024-06-15 오후 8 31 20" src="https://github.com/part4-project/effi_frontend/assets/51107943/7be1304d-94af-4f5d-ac7a-c16698d36e66">
<img width="579" alt="스크린샷 2024-06-15 오후 8 31 57" src="https://github.com/part4-project/effi_frontend/assets/51107943/6c73a40a-85ce-4e45-b624-515ccff38d7a">


## 🚨 관련 이슈
- close #134 
