### PR TITLE
드랍다운 보더 css 수정 및 리팩토링

### DIFF
--- a/src/pages/lobby/components/group-list-item.tsx
+++ b/src/pages/lobby/components/group-list-item.tsx
@@ -11,7 +11,7 @@ const GroupListItem = ({ groupName, onClick, groupNameLength }: GroupListItemPro
   return (
     <MeetingModalButton title="회의 생성">
       <S.Container $groupNameLength={groupNameLength} onClick={onClick}>
-        <S.FileImg>{groupName} </S.FileImg>
+        <S.FileImg>{groupName}</S.FileImg>
       </S.Container>
     </MeetingModalButton>
   );

--- a/src/pages/lobby/components/schedule-calendar.tsx
+++ b/src/pages/lobby/components/schedule-calendar.tsx
@@ -40,9 +40,9 @@ const ScheduleCalendar = () => {
       />
       <DropDownBox type="schedule-calendar" isDropdownOpen={true}>
         {filterdScheduleList.length ? (
-          filterdScheduleList.map((schedule, idx) => (
+          filterdScheduleList.map((schedule) => (
             <ScheduleListItem
-              key={idx}
+              key={schedule.id}
               groupId={schedule.id}
               groupName={schedule.group}
               meetingTitle={schedule.title}

--- a/src/pages/lobby/components/schedule-list-item.tsx
+++ b/src/pages/lobby/components/schedule-list-item.tsx
@@ -37,6 +37,10 @@ const S = {
   BorderBox: styled.div`
     padding-bottom: 4px;
     border-bottom: 1px solid ${(props) => props.theme.line};
+
+    &:last-child {
+      border-bottom: none;
+    }
   `,
   Container: styled(Link)`
     width: 100%;


### PR DESCRIPTION
## 🚀 작업 내용

- 드랍다운 보더 css 수정 및 리팩토링 하였습니다

## 📝 참고 사항

- 달력에서 스케줄 리스트 클릭하면 현재 미팅룸으로 가게 되어있는데 이 부분은 스케줄 리스트 api 나오면 수정하겠습니다(스케줄 리스트 데이터에 있을 그룹id를 이용해서 현재 zustand 이용한 그룹홈 이동하는 방식으로 적용하겠습니다)

## 🖼️ 스크린샷



## 🚨 관련 이슈

- 
