### PR TITLE
emptyNotice 컴포넌트 생성 후 적용

### DIFF
--- a/src/assets/icons/alert-circle-dark.svg
+++ b/src/assets/icons/alert-circle-dark.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="alert-circle">
+<path id="Vector" d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#FBFBFB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M12 8V12" stroke="#FBFBFB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M12 16H12.01" stroke="#FBFBFB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/assets/icons/alert-circle.svg
+++ b/src/assets/icons/alert-circle.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="alert-circle">
+<path id="Vector" d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#A6C4D5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_2" d="M12 8V12" stroke="#A6C4D5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path id="Vector_3" d="M12 16H12.01" stroke="#A6C4D5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/components/empty-notice/index.tsx
+++ b/src/components/empty-notice/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled, { useTheme } from 'styled-components';
+
+interface EmptyNoticeProps extends React.PropsWithChildren {
+  borderType?: 'none' | 'default';
+}
+
+const EmptyNotice = ({ children, borderType = 'default' }: EmptyNoticeProps) => {
+  const theme = useTheme();
+
+  return (
+    <S.Container $borderType={borderType}>
+      <S.Img src={theme.alertCircle} alt="경고" />
+      {children}
+    </S.Container>
+  );
+};
+
+export default EmptyNotice;
+
+const S = {
+  Container: styled.div<{ $borderType: EmptyNoticeProps['borderType'] }>`
+    width: 100%;
+    height: 100%;
+    border-radius: 5px;
+    border: ${({ $borderType, theme }) => ($borderType === 'none' ? 'none' : `2px solid ${theme.theme11}`)};
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    color: ${({ theme }) => theme.text08};
+    text-align: center;
+    font-size: 14px;
+    font-weight: 500;
+  `,
+  Img: styled.img`
+    width: 24px;
+    height: 24px;
+  `,
+};

--- a/src/components/modal/profile-modal/invited-list.tsx
+++ b/src/components/modal/profile-modal/invited-list.tsx
@@ -1,3 +1,4 @@
+import EmptyNotice from '@components/empty-notice';
 import {
   useInvitedGroupAcceptMutation,
   useInvitedGroupQuery,
@@ -48,7 +49,9 @@ const InvitedList = () => {
             </S.InvitedGroup>
           ))
         ) : (
-          <S.EmptyInvitedGroup>초대받은 그룹이 없습니다!</S.EmptyInvitedGroup>
+          <S.EmptyNoticeContainer>
+            <EmptyNotice>초대받은 그룹이 없습니다!</EmptyNotice>
+          </S.EmptyNoticeContainer>
         )}
       </S.InvitedList>
     </S.Container>
@@ -147,12 +150,8 @@ const S = {
   RejectButton: styled.img`
     ${BaseButton}
   `,
-  EmptyInvitedGroup: styled.div`
+  EmptyNoticeContainer: styled.div`
     width: 100%;
     height: 143px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: ${(props) => props.theme.input};
   `,
 };

--- a/src/pages/group-home/components/meeting-modal/meeting-form/meeting-topic-list.tsx
+++ b/src/pages/group-home/components/meeting-modal/meeting-form/meeting-topic-list.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import EmptyNotice from '@components/empty-notice';
 import ModifyDeleteButton from '@components/meeting/modify-delete-button';
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 import styled from 'styled-components';
@@ -54,7 +55,12 @@ const MeetingTopicList = ({ topicList, setTopicList }: MeetingTopicListProps) =>
     setTopicList(updatedList);
   };
 
-  if (!topicList.length) return <S.EmptyTopicList>추가된 안건이 없습니다!</S.EmptyTopicList>;
+  if (!topicList.length)
+    return (
+      <S.EmptyNoticeContainer>
+        <EmptyNotice>추가된 안건이 없습니다!</EmptyNotice>
+      </S.EmptyNoticeContainer>
+    );
 
   return (
     <DragDropContext onDragEnd={handleDragEnd}>
@@ -141,20 +147,10 @@ const S = {
     margin-left: 10px;
     cursor: pointer;
   `,
-  EmptyTopicList: styled.div`
+  EmptyNoticeContainer: styled.div`
     width: 100%;
     height: 110px;
-    background: ${(props) => props.theme.theme09};
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: var(--gray01);
-    font-size: 14px;
-    font-weight: 500;
-    letter-spacing: 0.56px;
-    border-radius: 5px;
   `,
-
   DropdownImg: styled.img`
     width: 16px;
     height: 16px;

--- a/src/pages/group-home/components/meeting-notes.tsx
+++ b/src/pages/group-home/components/meeting-notes.tsx
@@ -1,4 +1,5 @@
-import { ChangeEvent, KeyboardEventHandler, useState } from 'react';
+import { ChangeEvent, KeyboardEventHandler, useEffect, useState } from 'react';
+import EmptyNotice from '@components/empty-notice';
 import { NOTES_DATAS } from '@constants/mockdata';
 import { TNoteItem } from '@constants/mockdata.type';
 import DateRangeCalendar from '@pages/group-home/components/date-range-calendar';
@@ -12,6 +13,7 @@ const MeetingNotes = () => {
   const [dateRange, setDateRange] = useState<[Date | null, Date | null]>([null, null]);
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [inputValue, setInputValue] = useState<string>('');
+  const [isSearching, setIsSearching] = useState(false);
 
   const filteredNotes = filteredNotesBySearchQuery(NOTES_DATAS, dateRange, searchQuery);
 
@@ -28,6 +30,14 @@ const MeetingNotes = () => {
       setSearchQuery(e.target.value);
     }
   };
+
+  useEffect(() => {
+    if (searchQuery) {
+      setIsSearching(true);
+    } else {
+      setIsSearching(false);
+    }
+  }, [searchQuery]);
 
   return (
     <S.Container>
@@ -50,7 +60,13 @@ const MeetingNotes = () => {
 
       <S.MeetingNotesLists>
         {filteredNotes.length === 0 ? (
-          <div>해당 조건의 회의록이 없습니다.</div>
+          <S.EmptyNoticeContaier>
+            <EmptyNotice>
+              {isSearching
+                ? '해당 조건의 리포트가 없습니다.'
+                : `회의 리포트가 없습니다.\n회의를 진행하고 기록을 남겨보세요!`}
+            </EmptyNotice>
+          </S.EmptyNoticeContaier>
         ) : (
           filteredNotes.map((note: TNoteItem) => (
             <S.MeetingNoteItem key={note.id}>
@@ -115,5 +131,10 @@ const S = {
     position: absolute;
     top: 18%;
     right: 4%;
+  `,
+  EmptyNoticeContaier: styled.div`
+    line-height: 22px; /* 137.5% */
+    height: 300px;
+    white-space: pre-line;
   `,
 };

--- a/src/pages/lobby/components/schedule-calendar.tsx
+++ b/src/pages/lobby/components/schedule-calendar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import EmptyNotice from '@components/empty-notice';
 import { MY_SCHEDULE_LIST } from '@constants/mockdata';
 import { ko } from 'date-fns/locale';
 import DatePicker from 'react-datepicker';
@@ -49,7 +50,9 @@ const ScheduleCalendar = () => {
             />
           ))
         ) : (
-          <S.EmptyScheduleNotice>금일 스케줄이 없습니다!</S.EmptyScheduleNotice>
+          <S.EmptyNoticeContainer>
+            <EmptyNotice borderType="none">금일 스케줄이 없습니다.</EmptyNotice>
+          </S.EmptyNoticeContainer>
         )}
       </DropDownBox>
     </S.Container>
@@ -165,8 +168,6 @@ const S = {
     .react-datepicker__time-name {
       color: ${(props) => props.theme.scheduleText};
       display: inline-block;
-      width: 32px;
-      height: 32px;
       line-height: center;
       text-align: center;
       margin: 0;
@@ -228,7 +229,7 @@ const S = {
 
     .dot-container {
       position: absolute;
-      top: 120%;
+      top: calc(50% + 20px);
       left: 50%;
       transform: translate(-50%, -50%);
       display: flex;
@@ -242,11 +243,7 @@ const S = {
       border-radius: 100%;
     }
   `,
-  EmptyScheduleNotice: styled.div`
-    height: 80px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: ${(props) => props.theme.input};
+  EmptyNoticeContainer: styled.div`
+    height: 15vh;
   `,
 };

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -8,6 +8,8 @@ import ALARM_DARK from '@assets/icons/alarm-dark.svg';
 import ALARM_EMPTY_DARK from '@assets/icons/alarm-empty-dark.svg';
 import ALARM_EMPTY from '@assets/icons/alarm-empty.svg';
 import ALARM from '@assets/icons/alarm.svg';
+import ALERT_CIRCLE_DARK from '@assets/icons/alert-circle-dark.svg';
+import ALERT_CIRCLE from '@assets/icons/alert-circle.svg';
 import ARROW_DOWN_DARK from '@assets/icons/arrow-down-dark.svg';
 import ARROW_DOWN from '@assets/icons/arrow-down.svg';
 import ARROW_RIGHT_DARK from '@assets/icons/arrow-right-dark.svg';
@@ -69,6 +71,7 @@ export const lightModeTheme = {
   theme08: 'var(--blue04)',
   theme09: 'var(--dark08)',
   theme10: 'var(--white)',
+  theme11: 'var(--blue03)',
 
   //text color
   text01: 'var(--white)',
@@ -127,6 +130,7 @@ export const lightModeTheme = {
   check: INVITE_CHECK,
   reject: INVITE_REJECT,
   circle: CIRCLE_BLUE_5,
+  alertCircle: ALERT_CIRCLE,
 
   //other
   nickName: 'var(--dark02)',
@@ -158,6 +162,7 @@ export const darkModeTheme = {
   theme08: 'var(--dark08)',
   theme09: 'var(--dark03)',
   theme10: 'var(--dark04)',
+  theme11: 'var(--dark08)',
 
   //text color
   text01: 'var(--dark01)',
@@ -216,6 +221,7 @@ export const darkModeTheme = {
   check: INVITE_CHECK_DARK,
   reject: INVITE_REJECT_DARK,
   circle: CIRCLE_WHITE,
+  alertCircle: ALERT_CIRCLE_DARK,
 
   //other
   nickName: 'var(--dark07)',


### PR DESCRIPTION
## 🚀 작업 내용

- alert-circle 아이콘 추가(+dark 아이콘)
- 컴포넌트에 적용(로비, 그룹 홈, 내정보 모달, 회의 수정하기 모달)
- theme.ts 에 필요한 부분 추가

## 📝 참고 사항

- 그룹 홈에서 회의록 리스트는 
![image](https://github.com/part4-project/effi_frontend/assets/107683008/e938256e-84f3-4831-a1b1-19f0472fa383)
이런 식으로 검색시에는 다르게 나오게끔 조건에 나눠 문구 설정했습니다.


## 🖼️ 스크린샷
![image](https://github.com/part4-project/effi_frontend/assets/107683008/b116de1e-1ef7-4090-9da5-4e6d1669483e)
![image](https://github.com/part4-project/effi_frontend/assets/107683008/5dcca13b-7ca7-4043-adfb-9d8a78a992ac)
- 검색 O
![image](https://github.com/part4-project/effi_frontend/assets/107683008/0b9f1496-9913-4d4e-bc89-83cd0128eaf5)
- 검색 X
![image](https://github.com/part4-project/effi_frontend/assets/107683008/dc15ec37-7473-47e1-8608-c328797f45e0)



## 🚨 관련 이슈

- close #149 
