### PR TITLE
회의 생성 api 적용

### DIFF
--- a/src/api/meeting/meeting-request.ts
+++ b/src/api/meeting/meeting-request.ts
@@ -1,11 +1,16 @@
-import axios, { isAxiosError } from 'axios';
+import axios from '@api/axios';
+import { isAxiosError } from 'axios';
 import { TMeetingCreateReq } from './meeting-request.type';
 
 const meetingRequest = {
   createMeeting: async (meetingData: TMeetingCreateReq, groupId: number) => {
     try {
-      const { data } = await axios.post(`user/group/${groupId}/meeting/create`, meetingData);
-      return data;
+      const response = await axios.post(`user/group/${groupId}/meeting/create`, meetingData);
+      if (response.status == 200) {
+        return response.data;
+      } else {
+        throw response;
+      }
     } catch (error) {
       if (isAxiosError(error)) {
         if (error.response) {

--- a/src/components/modal/modal-button.tsx
+++ b/src/components/modal/modal-button.tsx
@@ -8,7 +8,7 @@ interface ModalButtonProp {
 
 const ModalButton = ({ children, onClick, type }: ModalButtonProp) => {
   return (
-    <S.Button $type={type} onClick={onClick}>
+    <S.Button $type={type} onClick={onClick} disabled={type === 'disable'}>
       {children}
     </S.Button>
   );
@@ -43,6 +43,7 @@ const S = {
             color: var(--dark08);
             background-color: var(--gray01, #9E9E9E);
             border: 1px solid transparent;
+            cursor: default;
             `;
       }
     }};

--- a/src/hooks/react-query/use-query-group.ts
+++ b/src/hooks/react-query/use-query-group.ts
@@ -29,11 +29,10 @@ export const useGroupCreateMutation = () => {
   const mutation = useMutation({
     mutationFn: async (groupData: string) => await groupRequest.createGroup(groupData),
     onSuccess: () => {
-      // Invalidate and refetch
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.groupList] });
       toast('그룹이 생성되었습니다');
     },
-    onError: (error: TAxiosError) => toast(error.errorMessage),
+    onError: (error: TAxiosError) => toast(error.errorMessage, true),
   });
 
   return mutation;
@@ -46,12 +45,11 @@ export const useGroupUpdateMutation = (groupId: number) => {
   const mutation = useMutation({
     mutationFn: async (groupName: string) => await groupRequest.updateGroup(groupName, groupId),
     onSuccess: () => {
-      // Invalidate and refetch
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.groupInfo, groupId] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.groupList] });
       toast('그룹명이 변경되었습니다');
     },
-    onError: (error: TAxiosError) => toast(error.errorMessage),
+    onError: (error: TAxiosError) => toast(error.errorMessage, true),
   });
 
   return mutation;
@@ -72,12 +70,11 @@ export const useInvitedGroupAcceptMutation = () => {
   const mutation = useMutation({
     mutationFn: async (groupId: number) => await groupRequest.acceptInvitedGroup(groupId),
     onSuccess: () => {
-      // Invalidate and refetch
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.invitedGroupList] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.groupList] });
       toast('초대가 수락되었습니다');
     },
-    onError: (error: TAxiosError) => toast(error.errorMessage),
+    onError: (error: TAxiosError) => toast(error.errorMessage, true),
   });
 
   return mutation;
@@ -90,12 +87,11 @@ export const useInvitedGroupRejectMutation = () => {
   const mutation = useMutation({
     mutationFn: async (groupId: number) => await groupRequest.rejectInvitedGroup(groupId),
     onSuccess: () => {
-      // Invalidate and refetch
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.invitedGroupList] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.groupList] });
       toast('초대를 거절했습니다');
     },
-    onError: (error: TAxiosError) => toast(error.errorMessage),
+    onError: (error: TAxiosError) => toast(error.errorMessage, true),
   });
 
   return mutation;
@@ -107,7 +103,7 @@ export const useGroupInviteMutation = (groupId: number) => {
   const mutation = useMutation({
     mutationFn: async (targetEmail: string) => await groupRequest.inviteGroup(targetEmail, groupId),
     onSuccess: () => toast('초대가 완료되었습니다'),
-    onError: (error: TAxiosError) => toast(error.errorMessage),
+    onError: (error: TAxiosError) => toast(error.errorMessage, true),
   });
   return mutation;
 };

--- a/src/hooks/react-query/use-query-meeting.ts
+++ b/src/hooks/react-query/use-query-meeting.ts
@@ -1,19 +1,23 @@
 /* eslint-disable no-console */
+import { TAxiosError } from '@api/axios';
 import meetingRequest from '@api/meeting/meeting-request';
 import { TMeetingCreateReq } from '@api/meeting/meeting-request.type';
 import { QUERY_KEY } from '@constants/query-key';
+import { useToast } from '@hooks/use-toast';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const useMeetingCreateMutation = (groupId: number) => {
+  const { toast } = useToast();
+
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async (meetingData: TMeetingCreateReq) => await meetingRequest.createMeeting(meetingData, groupId),
     onSuccess: () => {
-      // Invalidate and refetch
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.meetingList, groupId] });
+      toast('회의가 생성되었습니다');
     },
-    onError: (error) => console.error(`회의 생성 에러: ${error}`),
+    onError: (error: TAxiosError) => toast(error.errorMessage, true),
   });
 
   return mutation;

--- a/src/hooks/react-query/use-query-user.ts
+++ b/src/hooks/react-query/use-query-user.ts
@@ -20,12 +20,11 @@ export const useUserNicknameUpdateMutation = () => {
   const mutation = useMutation({
     mutationFn: async (nickName: string) => await userRequest.updateNickname(nickName),
     onSuccess: () => {
-      // Invalidate and refetch
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.userInfo] });
       queryClient.refetchQueries({ queryKey: [QUERY_KEY.groupInfo] });
       toast('닉네임이 변경되었습니다');
     },
-    onError: (error: TAxiosError) => toast(error.errorMessage),
+    onError: (error: TAxiosError) => toast(error.errorMessage, true),
   });
 
   return mutation;
@@ -38,11 +37,10 @@ export const useUserProfileImgUpdateMutation = () => {
   const mutation = useMutation({
     mutationFn: async (userData: File) => await userRequest.updateProfileImg(userData),
     onSuccess: () => {
-      // Invalidate and refetch
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.userInfo] });
       toast('프로필이미지가 변경되었습니다');
     },
-    onError: (error: TAxiosError) => toast(error.errorMessage),
+    onError: (error: TAxiosError) => toast(error.errorMessage, true),
   });
 
   return mutation;
@@ -55,11 +53,10 @@ export const useUserProfileImgDefaultMutation = () => {
   const mutation = useMutation({
     mutationFn: async () => await userRequest.updateProfileDefaultImg(),
     onSuccess: () => {
-      // Invalidate and refetch
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.userInfo] });
       toast('프로필이미지가 초기화 되었습니다');
     },
-    onError: (error: TAxiosError) => toast(error.errorMessage),
+    onError: (error: TAxiosError) => toast(error.errorMessage, true),
   });
 
   return mutation;

--- a/src/pages/group-home/utils/calculate-end-date.ts
+++ b/src/pages/group-home/utils/calculate-end-date.ts
@@ -1,0 +1,23 @@
+export const calculateEndDate = (selectedDate: Date | null, selectedTime: string): Date | null => {
+  if (!selectedDate) return null;
+
+  const hoursMatch = selectedTime.match(/(\d+)시간/);
+  const minutesMatch = selectedTime.match(/(\d+)분/);
+  let hours = 0;
+  let minutes = 0;
+
+  if (hoursMatch) {
+    hours = parseInt(hoursMatch[1]);
+  }
+  if (minutesMatch) {
+    minutes = parseInt(minutesMatch[1]);
+  }
+
+  const startDate = new Date(selectedDate.getTime()); // Clone the date
+
+  startDate?.setHours(startDate.getHours() + hours);
+  startDate?.setMinutes(startDate.getMinutes() + minutes);
+  const resultDate = startDate;
+
+  return resultDate;
+};

--- a/src/pages/group-home/utils/format-date-to-string.ts
+++ b/src/pages/group-home/utils/format-date-to-string.ts
@@ -5,3 +5,12 @@ export const formatDateToString = (date: Date | null) => {
   }
   throw new Error('전달된 인수가 Date 객체가 아닙니다.');
 };
+
+export const formatDateToISOStringWithOffset = (date: Date | null) => {
+  if (!date) return '';
+  const timezoneOffset = date.getTimezoneOffset() * 60000;
+  const localDate = new Date(date.getTime() - timezoneOffset);
+  const isoString = localDate.toISOString().slice(0, -1);
+
+  return isoString;
+};


### PR DESCRIPTION
## 🚀 작업 내용

- 회의 생성 api 적용 완료

- query onError 토스트에 true(색상 변경) 표시

## 📝 참고 사항

- RTC 구현 시 형식이 달라질 수 있습니다.

## 🖼️ 스크린샷

<img width="590" alt="스크린샷 2024-06-18 오후 8 26 36" src="https://github.com/part4-project/effi_frontend/assets/75316998/c22e5823-20d3-405d-96e2-2e8723feba08">

response
```json
{
    "id": 14,
    "meetingTitle": "회의 생성 테스트",
    "startDate": "2024-07-03T21:00:00",
    "expectedEndDate": "2024-07-03T22:30:00",
    "createdAt": "2024-06-18T11:26:22.35557803",
    "modifiedAt": "2024-06-18T11:26:22.35557803",
    "topicList": [
        {
            "topicName": "안건 테스트1",
            "isCompleted": false,
            "orderIndex": 0
        },
        {
            "topicName": "안건 테스트2",
            "isCompleted": false,
            "orderIndex": 1
        },
        {
            "topicName": "안건 테스트3",
            "isCompleted": false,
            "orderIndex": 2
        }
    ]
}
```


## 🚨 관련 이슈

- 
