### PR TITLE
로비 회의 생성 버튼 회의 생성 되게 수정

### DIFF
--- a/src/pages/group-home/components/meeting-modal/meeting-form/meeting-form.tsx
+++ b/src/pages/group-home/components/meeting-modal/meeting-form/meeting-form.tsx
@@ -5,6 +5,7 @@ import { calculateEndDate } from '@pages/group-home/utils/calculate-end-date';
 import { formatDateToISOStringWithOffset } from '@pages/group-home/utils/format-date-to-string';
 import roundTo15minutes from '@pages/group-home/utils/round-to-15minutes';
 import { useGroupStore } from '@stores/group';
+import { useLobbyGroupStore } from '@stores/lobby-group';
 import styled from 'styled-components';
 import MeetingDate from './meeting-date';
 import MeetingExpectedTime from './meeting-expected-time';
@@ -18,7 +19,8 @@ interface TMeetingFormProps {
   topicData?: TTopic;
 }
 const MeetingForm = ({ data, topicData }: TMeetingFormProps) => {
-  const groupId = useGroupStore((state) => state.groupId);
+  const lobbyGroupId = useLobbyGroupStore((state) => state.lobbyGroupId);
+  const groupId = useGroupStore((state) => state.groupId) || lobbyGroupId;
   const meetingCreate = useMeetingCreateMutation(groupId);
 
   const [selectedDate, setSelectedDate] = useState<Date | null>(roundTo15minutes(new Date()));

--- a/src/pages/group-home/components/meeting-modal/meeting-modal-button.tsx
+++ b/src/pages/group-home/components/meeting-modal/meeting-modal-button.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { TMeetingRoom, TTopic } from '@constants/mockdata.type';
+import { useLobbyGroupStore } from '@stores/lobby-group';
 import MeetingModal from '@/pages/group-home/components/meeting-modal/meeting-modal';
 
 interface MeetingModalButtonProps {
@@ -10,10 +11,15 @@ interface MeetingModalButtonProps {
 }
 
 const MeetingModalButton = ({ children, title, data, topicData }: MeetingModalButtonProps) => {
+  const { lobbyGroupId, initLobbyGroupId } = useLobbyGroupStore((state) => ({
+    lobbyGroupId: state.lobbyGroupId,
+    initLobbyGroupId: state.initLobbyGroupId,
+  }));
   const [isOpen, setIsOpen] = useState(false);
 
   const handleModalClose = () => {
     setIsOpen(false);
+    if (lobbyGroupId) initLobbyGroupId();
   };
 
   const handleOpenModalButtonClick = () => {

--- a/src/pages/lobby/components/group-list-item.tsx
+++ b/src/pages/lobby/components/group-list-item.tsx
@@ -1,16 +1,25 @@
 import MeetingModalButton from '@pages/group-home/components/meeting-modal/meeting-modal-button';
+import { useLobbyGroupStore } from '@stores/lobby-group';
 import styled from 'styled-components';
 
 interface GroupListItemProps {
+  groupId: number;
   groupName: string;
   onClick: () => void;
   groupNameLength: 'short' | 'long';
 }
 
-const GroupListItem = ({ groupName, onClick, groupNameLength }: GroupListItemProps) => {
+const GroupListItem = ({ groupId, groupName, onClick, groupNameLength }: GroupListItemProps) => {
+  const setLobbyGroupId = useLobbyGroupStore((state) => state.setLobbyGroupId);
+
+  const handleGroupClick = () => {
+    setLobbyGroupId(groupId);
+    onClick();
+  };
+
   return (
     <MeetingModalButton title="회의 생성">
-      <S.Container $groupNameLength={groupNameLength} onClick={onClick}>
+      <S.Container $groupNameLength={groupNameLength} onClick={handleGroupClick}>
         <S.FileImg>{groupName}</S.FileImg>
       </S.Container>
     </MeetingModalButton>

--- a/src/pages/lobby/components/my-group-list.tsx
+++ b/src/pages/lobby/components/my-group-list.tsx
@@ -20,6 +20,7 @@ const MyGroupList = ({ isLoading, onClick, groupData }: MyGroupListProps) => {
     .map((group) => (
       <GroupListItem
         key={group.groupId}
+        groupId={group.groupId}
         groupName={group.groupName}
         onClick={onClick}
         groupNameLength={checkGroupNameLong(group.groupName)}

--- a/src/stores/lobby-group/index.ts
+++ b/src/stores/lobby-group/index.ts
@@ -1,0 +1,6 @@
+import { create } from 'zustand';
+import { LobbyGroupState, selectLobbyGroupSlice } from './lobby-group-slice';
+
+export const useLobbyGroupStore = create<LobbyGroupState>((...set) => ({
+  ...selectLobbyGroupSlice(...set),
+}));

--- a/src/stores/lobby-group/lobby-group-slice.ts
+++ b/src/stores/lobby-group/lobby-group-slice.ts
@@ -1,0 +1,14 @@
+/* eslint-disable no-unused-vars */
+import { StateCreator } from 'zustand';
+
+export interface LobbyGroupState {
+  lobbyGroupId: number;
+  setLobbyGroupId: (lobbyGroupId: number) => void;
+  initLobbyGroupId: () => void;
+}
+
+export const selectLobbyGroupSlice: StateCreator<LobbyGroupState> = (set) => ({
+  lobbyGroupId: 0,
+  setLobbyGroupId: (lobbyGroupId: number) => set({ lobbyGroupId }),
+  initLobbyGroupId: () => set(() => ({ lobbyGroupId: 0 })),
+});


### PR DESCRIPTION

## 🚀 작업 내용
- lobbyGroupIdStore 생성
- 그룹생성 모달에 적용


## 📝 참고 사항

- 로비의 groupId 를 모달쪽에 넘겨서 구현하려고 했는데 너무 복잡해질 거 같아서 lobbyGroupIdstore 따로 만들어서 적용했습니다. (persist X)

## 🖼️ 스크린샷



## 🚨 관련 이슈

