### PR TITLE
미팅 모달 회의 생성하면 모달 닫히게 수정, 로비 퀵버튼 shadow 추가

### DIFF
--- a/src/pages/group-home/components/meeting-modal/meeting-form/meeting-form.tsx
+++ b/src/pages/group-home/components/meeting-modal/meeting-form/meeting-form.tsx
@@ -17,9 +17,13 @@ import MeetingTopicList from './meeting-topic-list';
 interface TMeetingFormProps {
   data?: TMeetingRoom;
   topicData?: TTopic;
+  onClose: () => void;
 }
-const MeetingForm = ({ data, topicData }: TMeetingFormProps) => {
-  const lobbyGroupId = useLobbyGroupStore((state) => state.lobbyGroupId);
+const MeetingForm = ({ data, topicData, onClose }: TMeetingFormProps) => {
+  const { lobbyGroupId, initLobbyGroupId } = useLobbyGroupStore((state) => ({
+    lobbyGroupId: state.lobbyGroupId,
+    initLobbyGroupId: state.initLobbyGroupId,
+  }));
   const groupId = useGroupStore((state) => state.groupId) || lobbyGroupId;
   const meetingCreate = useMeetingCreateMutation(groupId);
 
@@ -74,8 +78,15 @@ const MeetingForm = ({ data, topicData }: TMeetingFormProps) => {
     setTopic('');
   };
 
-  const handleSubmitButtonClick = () => {
-    meetingCreate.mutate(meetingData);
+  const handleSubmitButtonClick = async () => {
+    try {
+      await meetingCreate.mutateAsync(meetingData);
+      if (lobbyGroupId) initLobbyGroupId();
+      onClose();
+    } catch (error) {
+      setSelectedDate(roundTo15minutes(new Date()));
+      setSelectedTime('회의 시간을 선택해 주세요!');
+    }
   };
 
   useEffect(() => {

--- a/src/pages/group-home/components/meeting-modal/meeting-modal.tsx
+++ b/src/pages/group-home/components/meeting-modal/meeting-modal.tsx
@@ -13,7 +13,7 @@ interface MeetingModalProps {
 const MeetingModal = ({ isOpen, onClose, title, data, topicData }: MeetingModalProps) => {
   return (
     <Modal isOpen={isOpen} onClose={onClose} headerTitle={title}>
-      <MeetingForm data={data} topicData={topicData} />
+      <MeetingForm data={data} topicData={topicData} onClose={onClose} />
     </Modal>
   );
 };

--- a/src/pages/lobby/components/quick-button.tsx
+++ b/src/pages/lobby/components/quick-button.tsx
@@ -29,10 +29,15 @@ const S = {
     height: 138px;
     position: relative;
     cursor: pointer;
+    transition: transform 0.2s ease;
+    &:hover {
+      transform: translateY(-5px);
+    }
   `,
   BackgroundImg: styled.img`
     width: 100%;
     height: 100%;
+    filter: drop-shadow(1px 10px 5px rgba(0, 0, 0, 0.2));
   `,
   InnerBox: styled.div`
     position: absolute;


### PR DESCRIPTION
## 🚀 작업 내용
- 미팅 모달 회의 생성하면 모달 닫히게 수정
- 로비 퀵 버튼 shdow 추가 

## 📝 참고 사항
- 회의 생성시 성공하면 모달 닫히고 실패하면 실패 이유가 중복된 날짜 에러 밖에 없어서 날짜랑 시간만 초기화 되게끔 했습니다
- 회의 생성 실패시 이 부분 초기화
![image](https://github.com/part4-project/effi_frontend/assets/107683008/efb3f611-644b-4ae9-a8a6-e0449e8c0ca5)
- drop-shadow 라는 것을 발견했습니다 이미지에 맞게 쉐도우가 생깁니다
- 참고 블로그 https://gahyun-web-diary.tistory.com/92
```js
BackgroundImg: styled.img`
    width: 100%;
    height: 100%;
    filter: drop-shadow(1px 10px 5px rgba(0, 0, 0, 0.2));
  `,
``` 

## 🖼️ 스크린샷

![image](https://github.com/part4-project/effi_frontend/assets/107683008/e3bd7b32-242e-474a-832c-99a7b9c5852a)



## 🚨 관련 이슈

- 
