### PR TITLE
design: 회의 수정 아이콘 변경 및 다크모드 색상 변경

### DIFF
--- a/src/pages/group-home/components/meeting-box.tsx
+++ b/src/pages/group-home/components/meeting-box.tsx
@@ -48,7 +48,7 @@ const heartbeat = keyframes`
 const S = {
   Container: styled.div`
     position: relative;
-    background-color: var(--white);
+    background-color: ${(props) => props.theme.theme06};
     border-radius: 20px;
     aspect-ratio: 7/4;
     width: 472px;

--- a/src/pages/group-home/components/meetings.tsx
+++ b/src/pages/group-home/components/meetings.tsx
@@ -75,7 +75,7 @@ const Meetings = ({ isAdmin, scheduledMeeting }: TMeetingProps) => {
           <S.StyledModal>
             {isAdmin && (
               <MeetingModalButton title="회의 수정" data={MEETING_ROOM} topicData={TOPIC}>
-                <S.EditIcon src={editMeetingIcon} />
+                <S.EditIcon src={theme.editIcon} />
               </MeetingModalButton>
             )}
           </S.StyledModal>


### PR DESCRIPTION
## 🚀 작업 내용

- 회의 수정 아이콘 변경 및 다크모드 색상 변경

## 📝 참고 사항

- 예약된 회의 수정 아이콘 변경
- 다크모드일 때 색상 변경

## 🖼️ 스크린샷
![스크린샷 2024-06-23 오후 6 07 21](https://github.com/part4-project/effi_frontend/assets/75316998/6fe66c88-092e-4bde-9707-6d5935170087)



## 🚨 관련 이슈

- #190 
