### PR TITLE
캘린더 쿼리 select 옵션 추가로 지난 회의 필터링

### DIFF
--- a/src/hooks/react-query/use-query-meeting.ts
+++ b/src/hooks/react-query/use-query-meeting.ts
@@ -79,6 +79,13 @@ export const useCalendarMeetingQuery = (startMonth: string, endMonth: string) =>
   const query = useQuery<TCalendarMeetingFetchInfo[], Error>({
     queryKey: [QUERY_KEY.calendarMeetingList],
     queryFn: async () => await meetingRequest.fetchCalendarMeeting(startMonth, endMonth),
+    select: (data) => {
+      const currentDate = new Date();
+      return data.filter((meeting) => {
+        const meetingEndDate = new Date(meeting.expectedEndDate);
+        return meetingEndDate >= currentDate;
+      });
+    },
   });
   return query;
 };


### PR DESCRIPTION
## 🚀 작업 내용

캘린더 쿼리 select 옵션 추가로 지난 회의 필터링 하였습니다.

## 📝 참고 사항

- 

## 🖼️ 스크린샷



## 🚨 관련 이슈

- 
